### PR TITLE
Update and rename dreambox-dvb-modules-dreamtwo_4.9-20210217r0.bb to …

### DIFF
--- a/recipes-bsp/drivers/dreambox-dvb-modules-dreamtwo_4.9-20210217r0.bb
+++ b/recipes-bsp/drivers/dreambox-dvb-modules-dreamtwo_4.9-20210217r0.bb
@@ -1,6 +1,0 @@
-SRC_URI[dreamtwo.md5sum] = "77f3ba3815a507466c10153f8fd45ef5"
-SRC_URI[dreamtwo.sha256sum] = "228eb66ea016697539b40a67b60a348f275e4b384e3f50118f3723bf6f121cbe"
-
-require dreambox-dvb-modules-meson.inc
-
-COMPATIBLE_MACHINE = "^(dreamtwo)$"

--- a/recipes-bsp/drivers/dreambox-dvb-modules-dreamtwo_4.9-20210317r0.bb
+++ b/recipes-bsp/drivers/dreambox-dvb-modules-dreamtwo_4.9-20210317r0.bb
@@ -1,0 +1,6 @@
+SRC_URI[dreamtwo.md5sum] = "d81f60143a5bef7c092f9aa5b2f8e13f"
+SRC_URI[dreamtwo.sha256sum] = "5696710cf32b44ceec5c537b0455fd9b5652b90cf611f39670e68de403bf71d3"
+
+require dreambox-dvb-modules-meson.inc
+
+COMPATIBLE_MACHINE = "^(dreamtwo)$"


### PR DESCRIPTION
…dreambox-dvb-modules-dreamtwo_4.9-20210317r0.bb

- fixed H264 issues (e.g. for services of Scandinavia "Telenor/CanalDigital")
- fixed possible PCR/SCR issues